### PR TITLE
shutdown nginx properly on docker stop command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,4 +52,4 @@ cp /etc/nginx/external/*.conf /etc/nginx/conf.d/ 2> /dev/null > /dev/null
 # exec CMD
 echo ">> exec docker CMD"
 echo "$@"
-"$@"
+exec "$@"


### PR DESCRIPTION
This makes nginx replace the entrypoint.sh script as PID 1 and lets nginx do the SIGTERM signal handling.

Without this change docker stop blocks for 10 seconds before forcefully killing the container.
